### PR TITLE
Change cron schedule to run daily at midnight to prevent action and search abuse.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Metrics
 on:
-  schedule: [{cron: "0 * * * *"}]
+  schedule: [{cron: "0 0 * * *"}]
   workflow_dispatch:
   push: {branches: ["master", "main"]}
 jobs:


### PR DESCRIPTION
Updating the GitHub profile README every hour is unnecessarily frequent and causes the repository to constantly appear on the first page of search results when sorted by recently updated.

This change reduces the update frequency to a daily schedule, which keeps the profile content up to date while avoiding excessive repository activity and unintended visibility in search results.